### PR TITLE
Upgrade deprecated GitHub Actions in CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
             toolchain: stable
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
@@ -32,11 +32,10 @@ jobs:
         sudo apt-get install -y libsdl2-dev:${{ matrix.arch }} libsdl2-image-dev:${{ matrix.arch }}
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: ${{ matrix.toolchain }}
-          override: true
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
 
     - name: Install cross
       run: cargo install cross
@@ -45,7 +44,7 @@ jobs:
       run: cross build --target ${{ matrix.target }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.target }}
         path: target/${{ matrix.target }}/debug/*

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,9 +27,14 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo dpkg --add-architecture arm64
-        sudo apt-get update
-        sudo apt-get install -y libsdl2-dev:${{ matrix.arch }} libsdl2-image-dev:${{ matrix.arch }}
+        if [ "${{ matrix.arch }}" = "aarch64" ]; then
+          sudo dpkg --add-architecture arm64
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu libsdl2-dev:arm64 libsdl2-image-dev:arm64
+        else
+          sudo apt-get update
+          sudo apt-get install -y libsdl2-dev libsdl2-image-dev
+        fi
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
- Update actions/checkout from v2 to v4
- Update actions/upload-artifact from v2 to v4
- Replace deprecated actions-rs/toolchain@v1 with dtolnay/rust-toolchain@stable
- Fix parameter name from 'target' to 'targets' for new toolchain action

🤖 Generated with [Claude Code](https://claude.ai/code)